### PR TITLE
h[2-4]タグに属性（classやidなど）が付いていた場合にも置換するように対応

### DIFF
--- a/firsth3tagadsense.php
+++ b/firsth3tagadsense.php
@@ -11,9 +11,9 @@ License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 */
 
-define('H2_REG', "/<h2>[^<]*<\/h2>/i"); //h2Tag
-define('H3_REG', "/<h3>[^<]*<\/h3>/i"); //h3Tag
-define('H4_REG', "/<h4>[^<]*<\/h4>/i"); //h4Tag
+define('H2_REG', "/<h2.*?>[^<]*<\/h2>/i"); //h2Tag
+define('H3_REG', "/<h3.*?>[^<]*<\/h3>/i"); //h3Tag
+define('H4_REG', "/<h4.*?>[^<]*<\/h4>/i"); //h4Tag
 
 define('VERSION_NO', '3.0');
 


### PR DESCRIPTION
# 対応内容
- `<h2>見出し2</h2>`

上記のタグに対しては置換は行われますが、以下のようなタグに属性が付いている場合、置換が行われませんでした。

- `<h2 class="test">見出し2</h2>`
- `<h2 id="test">見出し2</h2>`

属性が付いている場合でも置換するよう対応をしました。

# 動作確認
- h2
- h3
- h4

上記のタグ全てで、属性の有無で動作確認しました。

# その他
何か理由があってタグの属性があった場合は置換しないとしているのであれば、プルリクを拒否していただいて大丈夫です。